### PR TITLE
Fix a potential destroy of a destroyed GTK widget.

### DIFF
--- a/panel-plugin/i3w-plugin.c
+++ b/panel-plugin/i3w-plugin.c
@@ -163,7 +163,11 @@ static void i3_remove_workspaces(i3WorkspacesPlugin *i3_workspaces)
     for (i = 1; i < I3_WORKSPACE_N; i++)
     {
         GtkWidget * button = i3_workspaces->buttons[i];
-        if (button) gtk_widget_destroy(button);
+        if (button)
+        {
+            gtk_widget_destroy(button);
+            i3_workspaces->buttons[i] = NULL;
+        }
     }
 }
 


### PR DESCRIPTION
Any item in workspaces->buttons should be set to NULL after the
corresponding workspace is destroyed.
