### PR TITLE
Bold the focused workspace.

### DIFF
--- a/panel-plugin/i3w-plugin.c
+++ b/panel-plugin/i3w-plugin.c
@@ -176,8 +176,28 @@ static void i3_add_workspaces(i3WorkspacesPlugin *i3_workspaces)
         i3workspace *workspace = workspaces[i];
         if (workspace)
         {
-            GtkWidget * button = gtk_button_new_with_label(workspace->name);
-            gtk_button_set_use_underline(GTK_BUTTON(button), workspace->focused);
+            GtkWidget * button;
+
+            button = gtk_button_new_with_label(workspace->name);
+
+            /* if focused, bold the text on the button; otherwise use regular boldness */
+            if (workspace->focused)
+            {
+                gchar * label_str;
+                GtkWidget * label;
+
+                label_str = (gchar *) calloc(strlen(workspace->name) + 8, sizeof(gchar));
+                strcpy(label_str, "<b>");
+                strcat(label_str, workspace->name);
+                strcat(label_str, "</b>");
+
+                label = gtk_bin_get_child(GTK_BIN(button));
+                gtk_label_set_markup(GTK_LABEL(label), label_str);
+
+                free(label_str);
+            }
+
+            gtk_button_set_use_underline(GTK_BUTTON(button), FALSE); /* avoid acceleration key interference */
             gtk_box_pack_start(GTK_BOX(i3_workspaces->hvbox), button, FALSE, FALSE, 0);
             gtk_widget_show(button);
             i3_workspaces->buttons[workspace->num] = button;
@@ -209,5 +229,8 @@ static void i3_on_workspace_blurred (i3workspace *workspace, gpointer data)
 static void i3_on_workspace_focused (i3workspace *workspace, gpointer data)
 {
     i3WorkspacesPlugin *i3_workspaces = (i3WorkspacesPlugin *) data;
+
+    i3_remove_workspaces(i3_workspaces);
+    i3_add_workspaces(i3_workspaces);
 }
 

--- a/panel-plugin/i3wm-delegate.c
+++ b/panel-plugin/i3wm-delegate.c
@@ -218,6 +218,8 @@ void on_focus_workspace(i3windowManager *i3wm, i3ipcCon *current, i3ipcCon *old)
 
     i3wm->lastBlurredWorkspace = blurredWorkspace;
 
+    blurredWorkspace->focused = 0;
+
     if (i3wm->workspaceInitialized)
     {
         add_workspace(i3wm, focusedName);
@@ -225,6 +227,7 @@ void on_focus_workspace(i3windowManager *i3wm, i3ipcCon *current, i3ipcCon *old)
     }
     else
     {
+        focusedWorkspace->focused = 1;
         if (i3wm->on_workspace_blurred) i3wm->on_workspace_blurred(blurredWorkspace, i3wm->on_workspace_blurred_data);
         if (i3wm->on_workspace_focused) i3wm->on_workspace_focused(focusedWorkspace, i3wm->on_workspace_focused_data);
     }


### PR DESCRIPTION
This focus adds the functionality to bold the button label corresponding to the workspace which is focused.

This pull request also correctly set the `focused` variable when workspace focus is changed.

`gtk_button_set_use_underline` calling is also modified because we don't want the acceleration key to interference. We have keys defined in `i3/config`. Please let me know if I am wrong.
