### PR TITLE
Supress a compilation warning.

### DIFF
--- a/panel-plugin/i3wm-delegate.c
+++ b/panel-plugin/i3wm-delegate.c
@@ -20,6 +20,7 @@
 #include <gtk/gtk.h>
 #include <glib/gprintf.h>
 #include <i3ipc-glib/i3ipc-glib.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "i3wm-delegate.h"


### PR DESCRIPTION
i3wm-delegate.c: In function 'i3wm_goto_workspace':
i3wm-delegate.c:124:36: warning: incompatible implicit declaration of built-in function 'malloc'
     gchar *command_str = (gchar *) malloc(cmd_size);
