### PR TITLE
Fix right click menu (Fixes #19)

### DIFF
--- a/panel-plugin/i3w-plugin.c
+++ b/panel-plugin/i3w-plugin.c
@@ -328,6 +328,9 @@ add_workspaces(i3WorkspacesPlugin *i3_workspaces)
             g_signal_connect(G_OBJECT(button), "clicked",
                     G_CALLBACK(on_workspace_clicked), i3_workspaces);
 
+            /* show the panel's right-click menu on this button */
+            xfce_panel_plugin_add_action_widget(i3_workspaces->plugin, button);
+
             /* avoid acceleration key interference */
             gtk_button_set_use_underline(GTK_BUTTON(button), FALSE);
             gtk_box_pack_end(GTK_BOX(i3_workspaces->hvbox), button, FALSE, FALSE, 0);


### PR DESCRIPTION
Adds an action widget to each button. Seems to work, but might not be the right way to do it.