### PR TITLE
Multi Monitor Support

### DIFF
--- a/panel-plugin/Makefile.am
+++ b/panel-plugin/Makefile.am
@@ -14,9 +14,11 @@ plugindir = \
 	$(libdir)/xfce4/panel/plugins
 
 libi3workspaces_la_SOURCES = \
+	i3w-multi-monitor-utils.c \
 	i3wm-delegate.c \
 	i3w-config.c \
 	i3w-plugin.c \
+	i3w-multi-monitor-utils.h \
 	i3wm-delegate.h \
 	i3w-config.h \
 	i3w-plugin.h
@@ -32,6 +34,8 @@ libi3workspaces_la_LDFLAGS = \
        -module \
        -no-undefined \
        -export-symbols-regex '^xfce_panel_module_(preinit|init|construct)' \
+       $(LIBX11_CFLAGS)
+       $(LIBXRANDR_CFLAGS)
        $(PLATFORM_LDFLAGS)
 
 libi3workspaces_la_LIBADD = \

--- a/panel-plugin/i3w-config.c
+++ b/panel-plugin/i3w-config.c
@@ -46,6 +46,8 @@ mode_color_changed(GtkWidget *button, i3WorkspacesConfig *config);
 void
 strip_workspace_numbers_changed(GtkWidget *button, i3WorkspacesConfig *config);
 void
+auto_detect_outputs_changed(GtkWidget *button, i3WorkspacesConfig *config);
+void
 output_changed(GtkWidget *entry, i3WorkspacesConfig *config);
 
 void
@@ -141,6 +143,8 @@ i3_workspaces_config_save(i3WorkspacesConfig *config, XfcePanelPlugin *plugin)
     xfce_rc_write_int_entry(rc, "mode_color", config->mode_color);
     xfce_rc_write_bool_entry(rc, "strip_workspace_numbers",
             config->strip_workspace_numbers);
+    xfce_rc_write_bool_entry(rc, "auto_detect_outputs",
+                             config->auto_detect_outputs);
     xfce_rc_write_entry(rc, "output", config->output);
 
     xfce_rc_close(rc);
@@ -198,6 +202,16 @@ i3_workspaces_config_show(i3WorkspacesConfig *config, XfcePanelPlugin *plugin,
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), config->strip_workspace_numbers == TRUE);
     g_signal_connect(G_OBJECT(button), "toggled", G_CALLBACK(strip_workspace_numbers_changed), config);
 
+    /* auto detect output */
+    hbox = gtk_hbox_new(FALSE, 3);
+    gtk_container_add(GTK_CONTAINER(dialog_vbox), hbox);
+    gtk_container_set_border_width(GTK_CONTAINER(hbox), 3);
+
+    button = gtk_check_button_new_with_mnemonic(_("Auto detect outputs"));
+    gtk_box_pack_start(GTK_BOX(hbox), button, FALSE, FALSE, 0);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), config->auto_detect_outputs == TRUE);
+    g_signal_connect(G_OBJECT(button), "toggled", G_CALLBACK(auto_detect_outputs_changed), config);
+
     /* output */
     hbox = gtk_hbox_new(FALSE, 3);
     gtk_container_add(GTK_CONTAINER(dialog_vbox), hbox);
@@ -227,6 +241,12 @@ void
 strip_workspace_numbers_changed(GtkWidget *button, i3WorkspacesConfig *config)
 {
     config->strip_workspace_numbers = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
+}
+
+void
+auto_detect_outputs_changed(GtkWidget *button, i3WorkspacesConfig *config)
+{
+  config->auto_detect_outputs = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
 }
 
 void

--- a/panel-plugin/i3w-config.c
+++ b/panel-plugin/i3w-config.c
@@ -120,6 +120,8 @@ i3_workspaces_config_load(i3WorkspacesConfig *config, XfcePanelPlugin *plugin)
     config->mode_color = xfce_rc_read_int_entry(rc, "mode_color", 0xff0000);
     config->strip_workspace_numbers = xfce_rc_read_bool_entry(rc,
             "strip_workspace_numbers", FALSE);
+    config->auto_detect_outputs = xfce_rc_read_bool_entry(rc,
+            "auto_detect_outputs", FALSE);
     config->output = g_strdup(xfce_rc_read_entry(rc, "output", ""));
 
     xfce_rc_close(rc);

--- a/panel-plugin/i3w-config.h
+++ b/panel-plugin/i3w-config.h
@@ -28,6 +28,7 @@ typedef struct
     guint32 urgent_color;
     guint32 mode_color;
     gboolean strip_workspace_numbers;
+    gboolean auto_detect_outputs;
     gchar *output;
 }
 i3WorkspacesConfig;

--- a/panel-plugin/i3w-multi-monitor-utils.c
+++ b/panel-plugin/i3w-multi-monitor-utils.c
@@ -91,6 +91,18 @@ get_outputs() {
 }
 
 /**
+ * free_outputs:
+ * @outputs: The outputs structure 
+ *
+ * Frees the allocated memory for an outputs structure
+ *
+ */
+void
+free_outputs(i3_workspaces_outputs_t outputs) {
+  free(outputs.outputs);
+}
+
+/**
  * get_monitor_name_at:
  * @outputs: The outputs information, as returned by get_outputs
  * @win_x: The X position of the coordinates to check

--- a/panel-plugin/i3w-multi-monitor-utils.c
+++ b/panel-plugin/i3w-multi-monitor-utils.c
@@ -91,18 +91,6 @@ get_outputs() {
 }
 
 /**
- * free_outputs:
- * @outputs: The outputs structure 
- *
- * Frees the allocated memory for an outputs structure
- *
- */
-void
-free_outputs(i3_workspaces_outputs_t outputs) {
-  free(outputs.outputs);
-}
-
-/**
  * get_monitor_name_at:
  * @outputs: The outputs information, as returned by get_outputs
  * @win_x: The X position of the coordinates to check

--- a/panel-plugin/i3w-multi-monitor-utils.c
+++ b/panel-plugin/i3w-multi-monitor-utils.c
@@ -77,8 +77,8 @@ char* get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y)
         int x_offs = outputs.outputs[o].x;
         int y_offs = outputs.outputs[o].y;
 
-        if (win_x >= x_offs && win_x <= x_offs + width &&
-            win_y >= y_offs && win_y <= y_offs + height) {
+        if (win_x >= x_offs && win_x < x_offs + width &&
+            win_y >= y_offs && win_y < y_offs + height) {
             return outputs.outputs[o].name;
         }
     }

--- a/panel-plugin/i3w-multi-monitor-utils.c
+++ b/panel-plugin/i3w-multi-monitor-utils.c
@@ -1,7 +1,17 @@
 #include "i3w-multi-monitor-utils.h"
 
-XRRCrtcInfo* find_crtc (Display* dpy, XRRScreenResources* res, RRCrtc xid) {
-    //assert(res);
+/**
+ * find_crtc:
+ * @dpy: The X Display
+ * @res: The XRandR screen resources
+ * @xid: The X Id of the crtc
+ *
+ * Find a crtc's information given its xid
+ *
+ * Returns: The crtc's information struct
+ */
+XRRCrtcInfo*
+find_crtc (Display* dpy, XRRScreenResources* res, RRCrtc xid) {
     XRRCrtcInfo* found = NULL;
     int c;
     for (c = 0; c < res->ncrtc && !found; ++c) {
@@ -12,13 +22,31 @@ XRRCrtcInfo* find_crtc (Display* dpy, XRRScreenResources* res, RRCrtc xid) {
     return found;
 }
 
-int is_connected (Connection c) {
+
+/**
+ * is_connected:
+ * @plugin: the xfce plugin object
+ *
+ * Does c mean connected display?
+ *
+ * Returns: True iff c indicated connected display
+ */
+int
+is_connected (Connection c) {
     return c == RR_Connected;
 }
 
 
-
-i3_workspaces_outputs_t get_outputs() {
+/**
+ * get_outputs:
+ *
+ * Gets the output information from XRandR. For each monitor, the
+ * output name, screen position and current resolution.
+ *
+ * Returns: The outputs structure. Must be freed with free_outputs.
+ */
+i3_workspaces_outputs_t
+get_outputs() {
     // Get Xlib information
     Display* dpy = XOpenDisplay (NULL); 
 	int screen = DefaultScreen (dpy);
@@ -71,7 +99,30 @@ i3_workspaces_outputs_t get_outputs() {
 
 }
 
-char* get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y) {
+/**
+ * free_outputs:
+ * @outputs: The outputs structure 
+ *
+ * Frees the allocated memory for an outputs structure
+ *
+ */
+void
+free_outputs(i3_workspaces_outputs_t outputs) {
+  free(outputs.outputs);
+}
+
+/**
+ * get_monitor_name_at:
+ * @outputs: The outputs information, as returned by get_outputs
+ * @win_x: The X position of the coordinates to check
+ * @win_y: The Y position of the coordinates to check
+ *
+ * Obtains the monitor name at a given X Screen coordinates.
+ *
+ * Returns: A string, representing the monitor name.
+ */
+char*
+get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y) {
     int o;
     for (o = 0; o < outputs.num_outputs; ++o) {
         int width = outputs.outputs[o].width;
@@ -87,6 +138,3 @@ char* get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y)
     return NULL;
 }
 
-void free_outputs(i3_workspaces_outputs_t outputs) {
-    free(outputs.outputs);
-}

--- a/panel-plugin/i3w-multi-monitor-utils.c
+++ b/panel-plugin/i3w-multi-monitor-utils.c
@@ -31,7 +31,7 @@ find_crtc (Display* dpy, XRRScreenResources* res, RRCrtc xid) {
  *
  * Returns: True iff c indicated connected display
  */
-int
+gboolean
 is_connected (Connection c) {
     return c == RR_Connected;
 }
@@ -70,28 +70,19 @@ get_outputs() {
         if (connected) {
             XRRCrtcInfo* info = find_crtc(dpy, res, output_info->crtc);
             if (info) {
-                char* name = output_info->name;
-                int width = info->width;
-                int height = info->height;
-                int x = info->x;
-                int y = info->y;
-
-                char* name_dest = malloc(strlen(name)*sizeof(char));
-                strcpy(name_dest, name);
-
                 i3_workspaces_output_t* output = &outputs.outputs[num_connected_outputs];
 
-                output->name = name_dest;
-                output->width = width;
-                output->height = height;
-                output->x = x;
-                output->y = y;
+                output->name = malloc(strlen(output_info->name)*sizeof(char));
+                strcpy(output->name, output_info->name);
 
-                num_connected_outputs += 1;
+                output->width = info->width;
+                output->height = info->height;
+                output->x = info->x;
+                output->y = info->y;
+
+                num_connected_outputs++;
             }
         }
-
-        outputs.num_outputs = num_connected_outputs;
     }
 
     outputs.num_outputs = num_connected_outputs;

--- a/panel-plugin/i3w-multi-monitor-utils.c
+++ b/panel-plugin/i3w-multi-monitor-utils.c
@@ -16,6 +16,8 @@ int is_connected (Connection c) {
     return c == RR_Connected;
 }
 
+
+
 i3_workspaces_outputs_t get_outputs() {
     // Get Xlib information
     Display* dpy = XOpenDisplay (NULL); 
@@ -85,9 +87,6 @@ char* get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y)
     return NULL;
 }
 
-int main () {
-    i3_workspaces_outputs_t outputs = get_outputs();
-
-    printf("%s\n", get_monitor_name_at(outputs, 2000, 10));
-
+void free_outputs(i3_workspaces_outputs_t outputs) {
+    free(outputs.outputs);
 }

--- a/panel-plugin/i3w-multi-monitor-utils.c
+++ b/panel-plugin/i3w-multi-monitor-utils.c
@@ -72,7 +72,7 @@ get_outputs() {
             if (info) {
                 i3_workspaces_output_t* output = &outputs.outputs[num_connected_outputs];
 
-                output->name = malloc(strlen(output_info->name)*sizeof(char));
+                output->name = malloc((strlen(output_info->name)+1)*sizeof(char));
                 strcpy(output->name, output_info->name);
 
                 output->width = info->width;
@@ -112,7 +112,7 @@ free_outputs(i3_workspaces_outputs_t outputs) {
  *
  * Returns: A string, representing the monitor name.
  */
-char*
+const char*
 get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y) {
     int o;
     for (o = 0; o < outputs.num_outputs; ++o) {

--- a/panel-plugin/i3w-multi-monitor-utils.c
+++ b/panel-plugin/i3w-multi-monitor-utils.c
@@ -1,0 +1,93 @@
+#include "i3w-multi-monitor-utils.h"
+
+XRRCrtcInfo* find_crtc (Display* dpy, XRRScreenResources* res, RRCrtc xid) {
+    //assert(res);
+    XRRCrtcInfo* found = NULL;
+    int c;
+    for (c = 0; c < res->ncrtc && !found; ++c) {
+        if (xid == res->crtcs[c]) {
+            found = XRRGetCrtcInfo(dpy, res, res->crtcs[c]);
+        }
+    }
+    return found;
+}
+
+int is_connected (Connection c) {
+    return c == RR_Connected;
+}
+
+i3_workspaces_outputs_t get_outputs() {
+    // Get Xlib information
+    Display* dpy = XOpenDisplay (NULL); 
+	int screen = DefaultScreen (dpy);
+    Window root = RootWindow (dpy, screen);
+	XRRScreenResources* res = XRRGetScreenResourcesCurrent (dpy, root);
+    int num_outputs = res->noutput;
+
+    // Allocate output
+    i3_workspaces_outputs_t outputs;
+    outputs.outputs = malloc(sizeof(i3_workspaces_output_t)*num_outputs);
+
+    // NOTE: We will only store connected outputs, even though we allocated space
+    // for all outputs. This is better than having to count the outputs first and 
+    // asking for space later.
+    int num_connected_outputs = 0; 
+    int o;
+    for (o = 0; o < num_outputs; ++o) {
+        XRROutputInfo *output_info = XRRGetOutputInfo(dpy, res, res->outputs[o]);
+        int connected = is_connected(output_info->connection);
+
+        if (connected) {
+            XRRCrtcInfo* info = find_crtc(dpy, res, output_info->crtc);
+            if (info) {
+                char* name = output_info->name;
+                int width = info->width;
+                int height = info->height;
+                int x = info->x;
+                int y = info->y;
+
+                char* name_dest = malloc(strlen(name)*sizeof(char));
+                strcpy(name_dest, name);
+
+                i3_workspaces_output_t* output = &outputs.outputs[num_connected_outputs];
+
+                output->name = name_dest;
+                output->width = width;
+                output->height = height;
+                output->x = x;
+                output->y = y;
+
+                num_connected_outputs += 1;
+            }
+        }
+
+        outputs.num_outputs = num_connected_outputs;
+    }
+
+    outputs.num_outputs = num_connected_outputs;
+    return outputs;
+
+}
+
+char* get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y) {
+    int o;
+    for (o = 0; o < outputs.num_outputs; ++o) {
+        int width = outputs.outputs[o].width;
+        int height = outputs.outputs[o].height;
+        int x_offs = outputs.outputs[o].x;
+        int y_offs = outputs.outputs[o].y;
+
+        if (win_x >= x_offs && win_x <= x_offs + width &&
+            win_y >= y_offs && win_y <= y_offs + height) {
+            return outputs.outputs[o].name;
+        }
+    }
+    return NULL;
+}
+
+int main () {
+    i3_workspaces_outputs_t outputs = get_outputs();
+
+    printf("%s\n", get_monitor_name_at(outputs, 2000, 10));
+
+}

--- a/panel-plugin/i3w-multi-monitor-utils.h
+++ b/panel-plugin/i3w-multi-monitor-utils.h
@@ -34,6 +34,6 @@ i3_workspaces_outputs_t get_outputs();
 
 void free_outputs();
 
-char* get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y);
+const char* get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y);
 
 #endif 

--- a/panel-plugin/i3w-multi-monitor-utils.h
+++ b/panel-plugin/i3w-multi-monitor-utils.h
@@ -32,8 +32,6 @@ typedef struct {
 
 i3_workspaces_outputs_t get_outputs();
 
-void free_outputs();
-
 char* get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y);
 
 #endif 

--- a/panel-plugin/i3w-multi-monitor-utils.h
+++ b/panel-plugin/i3w-multi-monitor-utils.h
@@ -31,6 +31,8 @@ typedef struct {
 
 i3_workspaces_outputs_t get_outputs();
 
+void free_outputs();
+
 char* get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y);
 
 #endif 

--- a/panel-plugin/i3w-multi-monitor-utils.h
+++ b/panel-plugin/i3w-multi-monitor-utils.h
@@ -32,6 +32,8 @@ typedef struct {
 
 i3_workspaces_outputs_t get_outputs();
 
+void free_outputs();
+
 char* get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y);
 
 #endif 

--- a/panel-plugin/i3w-multi-monitor-utils.h
+++ b/panel-plugin/i3w-multi-monitor-utils.h
@@ -15,6 +15,7 @@
 #include <inttypes.h>
 #include <stdarg.h>
 #include <math.h>
+#include <glib.h>
 
 typedef struct {
     int x;

--- a/panel-plugin/i3w-multi-monitor-utils.h
+++ b/panel-plugin/i3w-multi-monitor-utils.h
@@ -1,0 +1,36 @@
+#ifndef __MULTIMONITORUTILS_H_
+#define __MULTIMONITORUTILS_H_
+
+#include <stdio.h>
+#include <X11/Xlib.h>
+#include <X11/Xlibint.h>
+#include <X11/Xproto.h>
+#include <X11/Xatom.h>
+#include <X11/extensions/Xrandr.h>
+#include <X11/extensions/Xrender.h>	/* we share subpixel information */
+#include <strings.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdarg.h>
+#include <math.h>
+
+typedef struct {
+    int x;
+    int y;
+    int width;
+    int height;
+    char* name;
+} i3_workspaces_output_t;
+
+typedef struct {
+    int num_outputs; 
+    i3_workspaces_output_t* outputs;
+} i3_workspaces_outputs_t;
+
+i3_workspaces_outputs_t get_outputs();
+
+char* get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y);
+
+#endif 

--- a/panel-plugin/i3w-plugin.c
+++ b/panel-plugin/i3w-plugin.c
@@ -408,8 +408,9 @@ static void
 on_mode_changed(gchar *mode, gpointer data)
 {
     i3WorkspacesPlugin *i3_workspaces = (i3WorkspacesPlugin *) data;
-	if (!strncmp(mode, "default", 7))
+	if (!strncmp(mode, "default", 7)) {
 		gtk_label_set_text((GtkLabel *) i3_workspaces->mode_label, "");
+    }
 	else {
 		// allocate space for the maximum possible size of the label
 		gulong maxlen = strlen(mode) + 37;
@@ -423,7 +424,7 @@ on_mode_changed(gchar *mode, gpointer data)
 }
 
 /**
- * on_mode_changed:
+ * handle_change_output:
  * @i3_workspaces: the workspaces plugin
  *
  * Recomputes the panel's output based on XRandR's current data.
@@ -442,17 +443,15 @@ handle_change_output (i3WorkspacesPlugin* i3_workspaces)
     int x, y;
     GdkWindow* window = gtk_widget_get_window(i3_workspaces->ebox);
     gdk_window_get_root_origin(window, &x, &y);
-    //printf("Widget window coordinates: x:%d, y:%d\n", x, y);
 
     // Get the monitor name for the window location and set the config value
     char* output_name = get_monitor_name_at(outputs, x, y);
-    //printf("Widget is located in monitor: %s\n", output_name);
 
     i3_workspaces->config->output = output_name;
     remove_workspaces(i3_workspaces);
     add_workspaces(i3_workspaces);
 
-    free_outputs(outputs);
+    free(outputs.outputs);
 }
 
 /**

--- a/panel-plugin/i3w-plugin.c
+++ b/panel-plugin/i3w-plugin.c
@@ -451,7 +451,7 @@ handle_change_output (i3WorkspacesPlugin* i3_workspaces)
     remove_workspaces(i3_workspaces);
     add_workspaces(i3_workspaces);
 
-    free(outputs.outputs);
+    free_outputs(outputs);
 }
 
 /**

--- a/panel-plugin/i3w-plugin.c
+++ b/panel-plugin/i3w-plugin.c
@@ -463,15 +463,17 @@ static void handle_change_output (i3WorkspacesPlugin* i3_workspaces)
     int x, y;
     GdkWindow* window = gtk_widget_get_window(i3_workspaces->ebox);
     gdk_window_get_root_origin(window, &x, &y);
-    printf("Widget window coordinates: x:%d, y:%d\n", x, y);
+    //printf("Widget window coordinates: x:%d, y:%d\n", x, y);
 
     // Get the monitor name for the window location and set the config value
     char* output_name = get_monitor_name_at(outputs, x, y);
-    printf("Widget is located in monitor: %s\n", output_name);
+    //printf("Widget is located in monitor: %s\n", output_name);
 
     i3_workspaces->config->output = output_name;
     remove_workspaces(i3_workspaces);
     add_workspaces(i3_workspaces);
+
+    free_outputs(outputs);
 }
 
 /**
@@ -485,7 +487,6 @@ static void
 on_output_changed(gchar *mode, gpointer data)
 {
     i3WorkspacesPlugin *i3_workspaces = (i3WorkspacesPlugin *) data;
-    printf("Output changed\n");
     handle_change_output(i3_workspaces);
 }
 

--- a/panel-plugin/i3w-plugin.h
+++ b/panel-plugin/i3w-plugin.h
@@ -20,6 +20,7 @@
 #define __PLUGIN_H__
 
 #include "i3wm-delegate.h"
+#include "i3w-multi-monitor-utils.h"
 #include "i3w-config.h"
 
 G_BEGIN_DECLS

--- a/panel-plugin/i3wm-delegate.c
+++ b/panel-plugin/i3wm-delegate.c
@@ -46,7 +46,7 @@ static void
 subscribe_to_events(i3windowManager *i3w, GError **err);
 
 static void
-invoke_callback(const i3wmCallback callback, i3workspace *workspace);
+invoke_callback(const i3wmCallback callback);
 
 /*
  * Workspace event handlers
@@ -577,11 +577,11 @@ subscribe_to_events(i3windowManager *i3wm, GError **err)
  * Invokes the specified callback with the workspace as parameter.
  */
 static void
-invoke_callback(const i3wmCallback callback, i3workspace *workspace)
+invoke_callback(const i3wmCallback callback)
 {
     if (callback.function)
     {
-        callback.function(workspace, callback.data);
+        callback.function(callback.data);
     }
 }
 
@@ -618,7 +618,7 @@ on_focus_workspace(i3windowManager *i3wm, i3ipcCon *current, i3ipcCon *old)
 {
   GError *tmp_err = NULL;
   init_workspaces(i3wm, &tmp_err);
-  invoke_callback(i3wm->on_workspace_created, NULL);
+  invoke_callback(i3wm->on_workspace_focused);
 }
 
 /**
@@ -632,7 +632,7 @@ on_init_workspace(i3windowManager *i3wm)
 {
   GError *tmp_err = NULL;
   init_workspaces(i3wm, &tmp_err);
-  invoke_callback(i3wm->on_workspace_created, NULL);
+  invoke_callback(i3wm->on_workspace_created);
 }
 
 /**
@@ -646,7 +646,7 @@ on_empty_workspace(i3windowManager *i3wm)
 {
   GError *tmp_err = NULL;
   init_workspaces(i3wm, &tmp_err);
-  invoke_callback(i3wm->on_workspace_created, NULL);
+  invoke_callback(i3wm->on_workspace_destroyed);
 }
 
 /**
@@ -655,14 +655,14 @@ on_empty_workspace(i3windowManager *i3wm)
  *
  * Urgent workspace event handler.
  * This can mean two thigs: either a workspace became urgent or it was urgent and
- * not it isn't.
+ * now it isn't.
  */
 void
 on_urgent_workspace(i3windowManager *i3wm)
 {
   GError *tmp_err = NULL;
   init_workspaces(i3wm, &tmp_err);
-  invoke_callback(i3wm->on_workspace_created, NULL);
+  invoke_callback(i3wm->on_workspace_urgent);
 }
 
 /**
@@ -676,7 +676,9 @@ on_rename_workspace(i3windowManager *i3wm)
 {
   GError *tmp_err = NULL;
   init_workspaces(i3wm, &tmp_err);
-  invoke_callback(i3wm->on_workspace_created, NULL);
+  // Since created already removes/adds all the worskpaces,
+  // we don't need to also call the "destroyed" callback
+  invoke_callback(i3wm->on_workspace_created);
 }
 
 /**
@@ -690,7 +692,9 @@ on_move_workspace(i3windowManager *i3wm)
 {
   GError *tmp_err = NULL;
   init_workspaces(i3wm, &tmp_err);
-  invoke_callback(i3wm->on_workspace_created, NULL);
+  // Since created already removes/adds all the worskpaces,
+  // we don't need to also call the "destroyed" callback
+  invoke_callback(i3wm->on_workspace_created);
 }
 
 /**
@@ -720,7 +724,7 @@ on_output_event(i3ipcConnection *conn, i3ipcGenericEvent *e, gpointer i3w) {
     i3windowManager *i3wm = (i3windowManager *) i3w;
     GError *tmp_err = NULL;
     init_workspaces(i3wm, &tmp_err);
-    invoke_callback(i3wm->on_workspace_created, NULL);
+    invoke_callback(i3wm->on_workspace_created);
 }
 
 /**

--- a/panel-plugin/i3wm-delegate.c
+++ b/panel-plugin/i3wm-delegate.c
@@ -503,8 +503,6 @@ init_workspaces(i3windowManager *i3wm, GError **err)
 
     i3wm->wlist = NULL;
 
-    printf("It works!\n");
-
     GError *get_err = NULL;
     GSList *wlist = i3ipc_connection_get_workspaces(i3wm->connection, &get_err);
 

--- a/panel-plugin/i3wm-delegate.h
+++ b/panel-plugin/i3wm-delegate.h
@@ -30,7 +30,7 @@ typedef struct _i3workspace
     gchar *output;
 } i3workspace;
 
-typedef void (*i3wmWorkspaceCallback) (i3workspace *workspace, gpointer data);
+typedef void (*i3wmWorkspaceCallback) (gpointer data);
 typedef void (*i3wmModeCallback_fun) (gchar *mode, gpointer data);
 typedef void (*i3wmOutputCallback_fun) (gchar *mode, gpointer data);
 typedef void (*i3wmIpcShutdownCallback) (gpointer data);

--- a/panel-plugin/i3wm-delegate.h
+++ b/panel-plugin/i3wm-delegate.h
@@ -32,6 +32,7 @@ typedef struct _i3workspace
 
 typedef void (*i3wmWorkspaceCallback) (i3workspace *workspace, gpointer data);
 typedef void (*i3wmModeCallback_fun) (gchar *mode, gpointer data);
+typedef void (*i3wmOutputCallback_fun) (gchar *mode, gpointer data);
 typedef void (*i3wmIpcShutdownCallback) (gpointer data);
 
 typedef struct _i3wm_callback
@@ -46,6 +47,12 @@ typedef struct _i3wm_mode_callback
     gpointer data;
 } i3wmModeCallback;
 
+typedef struct _i3wm_output_callback
+{
+    i3wmOutputCallback_fun function;
+    gpointer data;
+} i3wmOutputCallback;
+
 typedef struct _i3windowManager
 {
     i3ipcConnection *connection;
@@ -58,6 +65,7 @@ typedef struct _i3windowManager
     i3wmCallback on_workspace_urgent;
     i3wmCallback on_workspace_renamed;
     i3wmModeCallback on_mode_changed;
+    i3wmOutputCallback on_output_changed;
     i3wmIpcShutdownCallback on_ipc_shutdown;
     gpointer on_ipc_shutdown_data;
 }
@@ -96,6 +104,9 @@ i3wm_set_on_workspace_renamed(i3windowManager *i3wm, i3wmWorkspaceCallback callb
 
 void
 i3wm_set_on_mode_changed(i3windowManager *i3wm, i3wmModeCallback_fun callback, gpointer data);
+
+void
+i3wm_set_on_output_changed(i3windowManager *i3wm, i3wmOutputCallback_fun callback, gpointer data);
 
 void
 i3wm_set_on_ipc_shutdown(i3windowManager *i3wm, i3wmIpcShutdownCallback callback, gpointer data);


### PR DESCRIPTION
As we discussed in issue #46, these are the changes that improve multi-monitor support. I've been testing this for a couple of days and it seems to behave now in the same way as i3bar.

As you can see, the new approach of "re-query everything on every workspace event" made some of the old events not make sense anymore. I did my best to try to adapt the old event codes to this refactor:

- I've kept all events in `i3wm-delegate`, but now they just call `init_workspaces` (the old structure is freed, if existing) and then call the most appropiate callback (or when none made sense, I just used `on_workspace_created` and noted that in a comment).
- I've replaced all callbacks in `i3w-plugin` by `on_workspace_changed`, so now all workspace events from i3 fire this function.

I added a new config flag called "Auto detect outputs", should be self explanatory. It's disabled by default. Feel free to change that if you think that's better.

I also tried to make the overall coding style match as closely as possible the already existing one. Please let me know if you would want me to improve something.