### PR TITLE
Added new color for visible (but unfocused) workspace and its config value

### DIFF
--- a/panel-plugin/i3w-config.c
+++ b/panel-plugin/i3w-config.c
@@ -42,6 +42,8 @@ focused_color_changed(GtkWidget *button, i3WorkspacesConfig *config);
 void
 urgent_color_changed(GtkWidget *button, i3WorkspacesConfig *config);
 void
+visible_color_changed(GtkWidget *button, i3WorkspacesConfig *config);
+void
 mode_color_changed(GtkWidget *button, i3WorkspacesConfig *config);
 void
 strip_workspace_numbers_changed(GtkWidget *button, i3WorkspacesConfig *config);
@@ -118,6 +120,7 @@ i3_workspaces_config_load(i3WorkspacesConfig *config, XfcePanelPlugin *plugin)
     config->focused_color = xfce_rc_read_int_entry(rc, "focused_color", 0x000000);
     config->urgent_color = xfce_rc_read_int_entry(rc, "urgent_color", 0xff0000);
     config->mode_color = xfce_rc_read_int_entry(rc, "mode_color", 0xff0000);
+    config->mode_color = xfce_rc_read_int_entry(rc, "visible_color", 0x000000);
     config->strip_workspace_numbers = xfce_rc_read_bool_entry(rc,
             "strip_workspace_numbers", FALSE);
     config->auto_detect_outputs = xfce_rc_read_bool_entry(rc,
@@ -143,6 +146,7 @@ i3_workspaces_config_save(i3WorkspacesConfig *config, XfcePanelPlugin *plugin)
     xfce_rc_write_int_entry(rc, "focused_color", config->focused_color);
     xfce_rc_write_int_entry(rc, "urgent_color", config->urgent_color);
     xfce_rc_write_int_entry(rc, "mode_color", config->mode_color);
+    xfce_rc_write_int_entry(rc, "visible_color", config->visible_color);
     xfce_rc_write_bool_entry(rc, "strip_workspace_numbers",
             config->strip_workspace_numbers);
     xfce_rc_write_bool_entry(rc, "auto_detect_outputs",
@@ -189,10 +193,11 @@ i3_workspaces_config_show(i3WorkspacesConfig *config, XfcePanelPlugin *plugin,
 
     dialog_vbox = GTK_DIALOG(dialog)->vbox;
 
-	add_color_picker(config, dialog_vbox, "Normal Workspace Color:", config->normal_color, normal_color_changed);
-	add_color_picker(config, dialog_vbox, "Focused Workspace Color:", config->focused_color, focused_color_changed);
-	add_color_picker(config, dialog_vbox, "Urgent Workspace Color:", config->urgent_color, urgent_color_changed);
-	add_color_picker(config, dialog_vbox, "Binding Mode Color:", config->mode_color, mode_color_changed);
+    add_color_picker(config, dialog_vbox, "Normal Workspace Color:", config->normal_color, normal_color_changed);
+    add_color_picker(config, dialog_vbox, "Focused Workspace Color:", config->focused_color, focused_color_changed);
+    add_color_picker(config, dialog_vbox, "Urgent Workspace Color:", config->urgent_color, urgent_color_changed);
+    add_color_picker(config, dialog_vbox, "Unfocused Visible Workspace Color:", config->visible_color, visible_color_changed);
+    add_color_picker(config, dialog_vbox, "Binding Mode Color:", config->mode_color, mode_color_changed);
 
     /* strip workspace numbers */
     hbox = gtk_hbox_new(FALSE, 3);
@@ -279,6 +284,14 @@ urgent_color_changed(GtkWidget *button, i3WorkspacesConfig *config)
     GdkColor color;
     gtk_color_button_get_color(GTK_COLOR_BUTTON(button), &color);
     config->urgent_color = serialize_gdkcolor(&color);
+}
+
+void
+visible_color_changed(GtkWidget *button, i3WorkspacesConfig *config)
+{
+  GdkColor color;
+  gtk_color_button_get_color(GTK_COLOR_BUTTON(button), &color);
+  config->visible_color = serialize_gdkcolor(&color);
 }
 
 void

--- a/panel-plugin/i3w-config.c
+++ b/panel-plugin/i3w-config.c
@@ -253,7 +253,7 @@ strip_workspace_numbers_changed(GtkWidget *button, i3WorkspacesConfig *config)
 void
 auto_detect_outputs_changed(GtkWidget *button, i3WorkspacesConfig *config)
 {
-  config->auto_detect_outputs = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
+    config->auto_detect_outputs = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
 }
 
 void
@@ -289,9 +289,9 @@ urgent_color_changed(GtkWidget *button, i3WorkspacesConfig *config)
 void
 visible_color_changed(GtkWidget *button, i3WorkspacesConfig *config)
 {
-  GdkColor color;
-  gtk_color_button_get_color(GTK_COLOR_BUTTON(button), &color);
-  config->visible_color = serialize_gdkcolor(&color);
+    GdkColor color;
+    gtk_color_button_get_color(GTK_COLOR_BUTTON(button), &color);
+    config->visible_color = serialize_gdkcolor(&color);
 }
 
 void

--- a/panel-plugin/i3w-config.h
+++ b/panel-plugin/i3w-config.h
@@ -25,6 +25,7 @@ typedef struct
 {
     guint32 normal_color;
     guint32 focused_color;
+    guint32 visible_color;
     guint32 urgent_color;
     guint32 mode_color;
     gboolean strip_workspace_numbers;

--- a/panel-plugin/i3w-plugin.c
+++ b/panel-plugin/i3w-plugin.c
@@ -494,9 +494,15 @@ set_button_label(GtkWidget *button, i3workspace *workspace,
     gulong maxlen = strlen(name) + 51;
     gchar *label_str = (gchar *) calloc(maxlen, sizeof(gchar));
 
+    // Set label color based on workspace state
+    guint32 color;
+    if (workspace->urgent) color = config->urgent_color;
+    else if (workspace->focused) color = config->focused_color;
+    else if (workspace->visible) color = config->visible_color;
+    else color = config->normal_color;
+
     g_snprintf(label_str, maxlen, template,
-            workspace->urgent ? config->urgent_color :
-                (workspace->focused ? config->focused_color : config->normal_color),
+            color,
             workspace->focused ? focused_weight : blurred_weight,
             name);
 

--- a/panel-plugin/i3wm-delegate.c
+++ b/panel-plugin/i3wm-delegate.c
@@ -366,6 +366,7 @@ create_workspace(i3ipcWorkspaceReply * wreply)
     workspace->num = wreply->num;
     workspace->name = g_strdup(wreply->name);
     workspace->focused = wreply->focused;
+    workspace->visible = wreply->visible;
     workspace->urgent = wreply->urgent;
     workspace->output = g_strdup(wreply->output);
 

--- a/panel-plugin/i3wm-delegate.h
+++ b/panel-plugin/i3wm-delegate.h
@@ -27,6 +27,7 @@ typedef struct _i3workspace
     gchar *name;
     gboolean focused;
     gboolean urgent;
+    gboolean visible;
     gchar *output;
 } i3workspace;
 


### PR DESCRIPTION
As we mentioned in #49, I implemented the new color in the configuration. 

About the naming, inside the code I have chosen to call this new color "visible", since that is the naming used by i3ipc-glib. At the config UI I have called it "Unfocused Visible Workspace Color", but feel free to suggest any other name that suits this better.

Also, I thought that the ternary comparison to decide the color would get a bit too big now that there are 4 different colors for workspace labels, so I replaced that by an if-else chain which is more readable IMO.

The rest of the changes are pretty self-explanatory