### PR TITLE
Allow the user to configure the style directly via CSS

### DIFF
--- a/panel-plugin/i3w-config.c
+++ b/panel-plugin/i3w-config.c
@@ -36,15 +36,7 @@ typedef struct {
 } ConfigDialogClosedParam;
 
 void
-normal_color_changed(GtkWidget *button, i3WorkspacesConfig *config);
-void
-focused_color_changed(GtkWidget *button, i3WorkspacesConfig *config);
-void
-urgent_color_changed(GtkWidget *button, i3WorkspacesConfig *config);
-void
-visible_color_changed(GtkWidget *button, i3WorkspacesConfig *config);
-void
-mode_color_changed(GtkWidget *button, i3WorkspacesConfig *config);
+css_changed(GtkTextBuffer *buffer, i3WorkspacesConfig *config);
 void
 strip_workspace_numbers_changed(GtkWidget *button, i3WorkspacesConfig *config);
 void
@@ -57,43 +49,6 @@ config_dialog_closed(GtkWidget *dialog, int response, ConfigDialogClosedParam *p
 
 /* Function Implementations */
 
-guint32
-serialize_gdkrgba(GdkRGBA *gdkrgba)
-{
-    guint32 color = 0;
-
-    // convert the GdkRGBA components to 8 bit ints
-    guint8 red_component = gdkrgba->red * 255;
-    guint8 green_component = gdkrgba->green * 255;
-    guint8 blue_component = gdkrgba->blue * 255;
-
-    // shift and add the color components
-    color += ((guint32) red_component) << 16;
-    color += ((guint32) green_component) << 8;
-    color += ((guint32) blue_component);
-
-    return color;
-}
-
-GdkRGBA *
-unserialize_gdkrgba(guint32 color)
-{
-    GdkRGBA *gdkrgba = g_new0(GdkRGBA, 1);
-
-    // Mask and shift the color components
-    guint8 red_component = (color & 0xff0000) >> 16;
-    guint8 green_component = (color & 0x00ff00) >> 8;
-    guint8 blue_component = (color & 0x0000ff);
-
-    // convert back to floats in range 0.0 to 1.0
-    gdkrgba->red = red_component / 255.0;
-    gdkrgba->green = green_component / 255.0;
-    gdkrgba->blue = blue_component / 255.0;
-    gdkrgba->alpha = 1.0;
-
-    return gdkrgba;
-}
-
 i3WorkspacesConfig *
 i3_workspaces_config_new()
 {
@@ -103,6 +58,7 @@ i3_workspaces_config_new()
 void
 i3_workspaces_config_free(i3WorkspacesConfig *config)
 {
+    g_free(config->css);
     g_free(config->output);
     g_free(config);
 }
@@ -110,18 +66,21 @@ i3_workspaces_config_free(i3WorkspacesConfig *config)
 gboolean
 i3_workspaces_config_load(i3WorkspacesConfig *config, XfcePanelPlugin *plugin)
 {
-    gchar *file = xfce_panel_plugin_lookup_rc_file(plugin);
+    gchar *file = xfce_panel_plugin_save_location(plugin, FALSE);
     if (G_UNLIKELY(!file))
         return FALSE;
 
     XfceRc *rc = xfce_rc_simple_open(file, FALSE);
     g_free(file);
 
-    config->normal_color = xfce_rc_read_int_entry(rc, "normal_color", 0x000000);
-    config->focused_color = xfce_rc_read_int_entry(rc, "focused_color", 0x000000);
-    config->urgent_color = xfce_rc_read_int_entry(rc, "urgent_color", 0xff0000);
-    config->mode_color = xfce_rc_read_int_entry(rc, "mode_color", 0xff0000);
-    config->visible_color = xfce_rc_read_int_entry(rc, "visible_color", 0x000000);
+    const gchar default_css[] =
+        ".workspace { }\n"
+        ".workspace.visible { }\n"
+        ".workspace.focused { font-weight: bold; }\n"
+        ".workspace.urgent { color: red; }\n"
+        ".binding-mode { }\n";
+
+    config->css = g_strdup(xfce_rc_read_entry(rc, "css", default_css));
     config->strip_workspace_numbers = xfce_rc_read_bool_entry(rc,
             "strip_workspace_numbers", FALSE);
     config->auto_detect_outputs = xfce_rc_read_bool_entry(rc,
@@ -143,11 +102,7 @@ i3_workspaces_config_save(i3WorkspacesConfig *config, XfcePanelPlugin *plugin)
     XfceRc *rc = xfce_rc_simple_open(file, FALSE);
     g_free(file);
 
-    xfce_rc_write_int_entry(rc, "normal_color", config->normal_color);
-    xfce_rc_write_int_entry(rc, "focused_color", config->focused_color);
-    xfce_rc_write_int_entry(rc, "urgent_color", config->urgent_color);
-    xfce_rc_write_int_entry(rc, "mode_color", config->mode_color);
-    xfce_rc_write_int_entry(rc, "visible_color", config->visible_color);
+    xfce_rc_write_entry(rc, "css", config->css);
     xfce_rc_write_bool_entry(rc, "strip_workspace_numbers",
             config->strip_workspace_numbers);
     xfce_rc_write_bool_entry(rc, "auto_detect_outputs",
@@ -159,27 +114,12 @@ i3_workspaces_config_save(i3WorkspacesConfig *config, XfcePanelPlugin *plugin)
     return TRUE;
 }
 
-void add_color_picker(i3WorkspacesConfig *config, GtkWidget *dialog_vbox, char *text, guint32 color, gpointer callback) {
-    GtkWidget *hbox, *button, *label;
-
-    /* focused color */
-    hbox = gtk_box_new(FALSE, 3);
-    gtk_container_add(GTK_CONTAINER(dialog_vbox), hbox);
-    gtk_container_set_border_width(GTK_CONTAINER(hbox), 3);
-
-    label = gtk_label_new(_(text));
-    gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, FALSE, 0);
-
-    button = gtk_color_button_new_with_rgba(unserialize_gdkrgba(color));
-    gtk_box_pack_start(GTK_BOX(hbox), button, FALSE, FALSE, 0);
-    g_signal_connect(G_OBJECT(button), "color-set", G_CALLBACK(callback), config);
-}
-
 void
 i3_workspaces_config_show(i3WorkspacesConfig *config, XfcePanelPlugin *plugin,
         ConfigChangedCallback cb, gpointer cb_data)
 {
-    GtkWidget *dialog, *dialog_content, *hbox, *button, *label;
+    GtkWidget *dialog, *dialog_content, *hbox, *view, *button, *label;
+    GtkTextBuffer *buffer;
 
     xfce_panel_plugin_block_menu(plugin);
 
@@ -197,11 +137,16 @@ i3_workspaces_config_show(i3WorkspacesConfig *config, XfcePanelPlugin *plugin,
 
     dialog_content = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 
-    add_color_picker(config, dialog_content, "Normal Workspace Color:", config->normal_color, normal_color_changed);
-    add_color_picker(config, dialog_content, "Focused Workspace Color:", config->focused_color, focused_color_changed);
-    add_color_picker(config, dialog_content, "Urgent Workspace Color:", config->urgent_color, urgent_color_changed);
-    add_color_picker(config, dialog_content, "Unfocused Visible Workspace Color:", config->visible_color, visible_color_changed);
-    add_color_picker(config, dialog_content, "Binding Mode Color:", config->mode_color, mode_color_changed);
+    /* CSS */
+    hbox = gtk_box_new(FALSE, 3);
+    gtk_container_add(GTK_CONTAINER(dialog_content), hbox);
+    gtk_container_set_border_width(GTK_CONTAINER(hbox), 3);
+
+    view = gtk_text_view_new();
+    buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW (view));
+    gtk_text_buffer_set_text(buffer, config->css, -1);
+    gtk_box_pack_start(GTK_BOX(hbox), view, FALSE, FALSE, 0);
+    g_signal_connect(G_OBJECT(buffer), "changed", G_CALLBACK(css_changed), config);
 
     /* strip workspace numbers */
     hbox = gtk_box_new(FALSE, 3);
@@ -249,6 +194,14 @@ i3_workspaces_config_show(i3WorkspacesConfig *config, XfcePanelPlugin *plugin,
 }
 
 void
+css_changed(GtkTextBuffer *buffer, i3WorkspacesConfig *config)
+{
+    GtkTextIter start, end;
+    gtk_text_buffer_get_bounds(buffer, &start, &end);
+    config->css = g_strdup(gtk_text_buffer_get_text(buffer, &start, &end, FALSE));
+}
+
+void
 strip_workspace_numbers_changed(GtkWidget *button, i3WorkspacesConfig *config)
 {
     config->strip_workspace_numbers = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
@@ -264,47 +217,6 @@ void
 output_changed(GtkWidget *entry, i3WorkspacesConfig *config)
 {
     config->output = g_strdup(gtk_entry_get_text(GTK_ENTRY(entry)));
-}
-
-void
-normal_color_changed(GtkWidget *button, i3WorkspacesConfig *config)
-{
-    GdkRGBA color;
-    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(button), &color);
-    config->normal_color = serialize_gdkrgba(&color);
-}
-
-void
-focused_color_changed(GtkWidget *button, i3WorkspacesConfig *config)
-{
-    GdkRGBA color;
-    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(button), &color);
-    config->focused_color = serialize_gdkrgba(&color);
-}
-
-void
-urgent_color_changed(GtkWidget *button, i3WorkspacesConfig *config)
-{
-    GdkRGBA color;
-    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(button), &color);
-    config->urgent_color = serialize_gdkrgba(&color);
-}
-
-void
-visible_color_changed(GtkWidget *button, i3WorkspacesConfig *config)
-{
-    GdkRGBA color;
-    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(button), &color);
-    config->visible_color = serialize_gdkrgba(&color);
-}
-
-void
-
-mode_color_changed(GtkWidget *button, i3WorkspacesConfig *config)
-{
-    GdkRGBA color;
-    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(button), &color);
-    config->mode_color = serialize_gdkrgba(&color);
 }
 
 void

--- a/panel-plugin/i3w-config.c
+++ b/panel-plugin/i3w-config.c
@@ -110,7 +110,7 @@ i3_workspaces_config_free(i3WorkspacesConfig *config)
 gboolean
 i3_workspaces_config_load(i3WorkspacesConfig *config, XfcePanelPlugin *plugin)
 {
-    gchar *file = xfce_panel_plugin_save_location(plugin, FALSE);
+    gchar *file = xfce_panel_plugin_lookup_rc_file(plugin);
     if (G_UNLIKELY(!file))
         return FALSE;
 

--- a/panel-plugin/i3w-config.h
+++ b/panel-plugin/i3w-config.h
@@ -23,11 +23,7 @@
 
 typedef struct
 {
-    guint32 normal_color;
-    guint32 focused_color;
-    guint32 visible_color;
-    guint32 urgent_color;
-    guint32 mode_color;
+    gchar *css;
     gboolean strip_workspace_numbers;
     gboolean auto_detect_outputs;
     gchar *output;
@@ -35,12 +31,6 @@ typedef struct
 i3WorkspacesConfig;
 
 typedef void (*ConfigChangedCallback) (gpointer cb_data);
-
-/* utility functions */
-guint32
-serialize_gdkrgba(GdkRGBA *gdkrgba);
-GdkRGBA *
-unserialize_gdkrgba(guint32 color);
 
 /* interface functions */
 i3WorkspacesConfig *

--- a/panel-plugin/i3w-plugin.h
+++ b/panel-plugin/i3w-plugin.h
@@ -30,6 +30,8 @@ typedef struct
 {
     XfcePanelPlugin *plugin;
 
+    GtkCssProvider *css_provider;
+
     /* panel widgets */
     GtkWidget       *ebox;
     GtkWidget       *hvbox;


### PR DESCRIPTION
Instead of trying to expose all the style options through a GUI, just add a text editor and let the user figure it out themselves. This also has the side effect of allowing for sane defaults and following GTK themes. This also fixes #29, #31, and possibly #43.

I've set the default CSS to be a minimal example vaguely similar to the previous defaults, and providing examples of all the classes I added (screenshots are taken with the panel's background color set to black, and my theme's default text color):
```css
.workspace { }
.workspace.visible { }
.workspace.focused { font-weight: bold; }
.workspace.urgent { color: red; }
.binding-mode { }
```
![defaults](https://user-images.githubusercontent.com/4205882/104085341-99555380-521c-11eb-9df7-9058d33d350b.png)


Here's an example of styling it to look like the defaults for i3bar:
```css
.workspace, .binding-mode {
    border: 1px solid;
    font: DejaVu Sans Mono;
    margin-bottom: 1px;
}

.workspace label, .binding-mode label {
    padding: 2px;
}

/* inactive defaults */
.workspace {
    border-color: #333333;
    background-color: #222222;
    color: #888888;
}

/* equivalent to "active_workspace" in i3bar */
.workspace.visible {
    border-color: #333333;
    background-color: #5f676a;
    color: #ffffff;
}

.workspace.focused {
    border-color: #4c7899;
    background-color: #285577;
    color: #ffffff;
}

.workspace.urgent {
    border-color: #2f343a;
    background-color: #900000;
    color: #ffffff;
}

.binding-mode {
    border-color: #2f343a;
    background-color: #900000;
    color: #ffffff;
}
```
![i3bar-ish](https://user-images.githubusercontent.com/4205882/104085302-3fed2480-521c-11eb-87cf-7a349fdb5728.png)