### PR TITLE
Handle spaces in workspace names properly

### DIFF
--- a/panel-plugin/i3w-multi-monitor-utils.h
+++ b/panel-plugin/i3w-multi-monitor-utils.h
@@ -32,7 +32,7 @@ typedef struct {
 
 i3_workspaces_outputs_t get_outputs();
 
-void free_outputs();
+void free_outputs(i3_workspaces_outputs_t);
 
 const char* get_monitor_name_at(i3_workspaces_outputs_t outputs, int win_x, int win_y);
 

--- a/panel-plugin/i3wm-delegate.c
+++ b/panel-plugin/i3wm-delegate.c
@@ -326,7 +326,7 @@ i3wm_goto_workspace(i3windowManager *i3wm, i3workspace *workspace, GError **err)
     size_t cmd_size = (13 + strlen(workspace->name)) * sizeof(gchar);
     gchar *command_str = (gchar *) malloc(cmd_size);
     memset(command_str, 0, cmd_size);
-    sprintf(command_str, "workspace %s", workspace->name);
+    sprintf(command_str, "workspace \"%s\"", workspace->name);
 
     GError *ipc_err = NULL;
 


### PR DESCRIPTION
This small patch fixes an issue `i3wm_goto_workspace` would create a new workspace instead of switching to an existing one if the name begins with a space.

I have spaces in workspace names to work around the issue with this plugin. I couldn't figure out how to add spaces around numbers using a stylesheet. Otherwise, without spaces, the buttons appear too thin on a HiDPI display.